### PR TITLE
Fix duplicate waypoints

### DIFF
--- a/src/main/java/com/oitsjustjose/geolosys/journeymap/ForgeEventListener.java
+++ b/src/main/java/com/oitsjustjose/geolosys/journeymap/ForgeEventListener.java
@@ -32,9 +32,10 @@ public class ForgeEventListener
                     if (jmAPI.playerAccepts(Lib.MODID, DisplayType.Waypoint))
                     {
                         String name = new ItemStack(state.getBlock(), 1, state.getBlock().getMetaFromState(state)).getDisplayName();
+                        String id = Lib.MODID + " - " + name + " - " + event.getWorld().getChunkFromBlockCoords(event.getPos()).getPos();
                         try
                         {
-                            jmAPI.show(new Waypoint(Lib.MODID, name, event.getWorld().provider.getDimension(), event.getPos()));
+                            jmAPI.show(new Waypoint(Lib.MODID, id, name, event.getWorld().provider.getDimension(), event.getPos()));
                         }
                         catch (Throwable t)
                         {


### PR DESCRIPTION
When creating a new waypoint, if a waypoint with the same name and chunk coords. already exists, the old waypoint will now be overwritten.

Edit:
This won't work with waypoints created with previous versions of Geolosys, since they were automatically assigned a UUID.