### PR TITLE
Add new configurable Prospector's Pickaxe mode

### DIFF
--- a/src/main/java/com/oitsjustjose/geolosys/config/ModConfig.java
+++ b/src/main/java/com/oitsjustjose/geolosys/config/ModConfig.java
@@ -53,6 +53,10 @@ public class ModConfig
         @Config.RangeInt(min = 0, max = 255)
         public int proPickRange = 5;
 
+        @Config.Name("Prospector's Pickaxe Diameter")
+        @Config.RangeInt(min = 0, max = 255)
+        public int proPickDiameter = 5;
+
         @Config.Name("Enable Extra Compass Features")
         public boolean enableEnhancedCompass = true;
 

--- a/src/main/java/com/oitsjustjose/geolosys/items/ItemProPick.java
+++ b/src/main/java/com/oitsjustjose/geolosys/items/ItemProPick.java
@@ -78,18 +78,19 @@ public class ItemProPick extends Item
         int zStart;
         int zEnd;
         int confAmt = ModConfig.featureControl.proPickRange;
+        int confDmt = ModConfig.featureControl.proPickDiameter;
 
         boolean found = false;
 
         switch (facing)
         {
             case UP:
-                xStart = -(confAmt / 2);
-                xEnd = confAmt / 2;
+                xStart = -(confDmt / 2);
+                xEnd = confDmt / 2;
                 yStart = -confAmt;
                 yEnd = 0;
-                zStart = -(confAmt / 2);
-                zEnd = (confAmt / 2);
+                zStart = -(confDmt / 2);
+                zEnd = (confDmt / 2);
                 for (int x = xStart; x <= xEnd; x++)
                 {
                     for (int y = yStart; y <= yEnd; y++)
@@ -108,12 +109,12 @@ public class ItemProPick extends Item
                 }
                 break;
             case DOWN:
-                xStart = -(confAmt / 2);
-                xEnd = confAmt / 2;
+                xStart = -(confDmt / 2);
+                xEnd = confDmt / 2;
                 yStart = 0;
                 yEnd = confAmt;
-                zStart = -(confAmt / 2);
-                zEnd = confAmt / 2;
+                zStart = -(confDmt / 2);
+                zEnd = confDmt / 2;
                 for (int x = xStart; x <= xEnd; x++)
                 {
                     for (int y = yStart; y <= yEnd; y++)
@@ -132,10 +133,10 @@ public class ItemProPick extends Item
                 }
                 break;
             case NORTH:
-                xStart = -(confAmt / 2);
-                xEnd = confAmt / 2;
-                yStart = -(confAmt / 2);
-                yEnd = confAmt / 2;
+                xStart = -(confDmt / 2);
+                xEnd = confDmt / 2;
+                yStart = -(confDmt / 2);
+                yEnd = confDmt / 2;
                 zStart = 0;
                 zEnd = confAmt;
                 for (int x = xStart; x <= xEnd; x++)
@@ -156,10 +157,10 @@ public class ItemProPick extends Item
                 }
                 break;
             case SOUTH:
-                xStart = -(confAmt / 2);
-                xEnd = confAmt / 2;
-                yStart = -(confAmt / 2);
-                yEnd = confAmt / 2;
+                xStart = -(confDmt / 2);
+                xEnd = confDmt / 2;
+                yStart = -(confDmt / 2);
+                yEnd = confDmt / 2;
                 zStart = -confAmt;
                 zEnd = 0;
 
@@ -183,10 +184,10 @@ public class ItemProPick extends Item
             case EAST:
                 xStart = -(confAmt);
                 xEnd = 0;
-                yStart = -(confAmt / 2);
-                yEnd = confAmt / 2;
-                zStart = -(confAmt / 2);
-                zEnd = confAmt / 2;
+                yStart = -(confDmt / 2);
+                yEnd = confDmt / 2;
+                zStart = -(confDmt / 2);
+                zEnd = confDmt / 2;
 
                 for (int x = xStart; x <= xEnd; x++)
                 {
@@ -208,10 +209,10 @@ public class ItemProPick extends Item
             case WEST:
                 xStart = 0;
                 xEnd = confAmt;
-                yStart = -(confAmt / 2);
-                yEnd = confAmt / 2;
-                zStart = -(confAmt / 2);
-                zEnd = confAmt / 2;
+                yStart = -(confDmt / 2);
+                yEnd = confDmt / 2;
+                zStart = -(confDmt / 2);
+                zEnd = confDmt / 2;
                 for (int x = xStart; x <= xEnd; x++)
                 {
                     for (int y = yStart; y <= yEnd; y++)


### PR DESCRIPTION
Hello. I just added little upgrade to Prospector's Pickaxe work mode. Before pickaxe checked only cube Range^3, now pickaxe checks cuboid Diameter^2 x Range.

Changes:
1 Add new config entry "Prospector's Pickaxe Diameter"
2 Pickaxe can now act in "ray" mode when configured Range longer than Diameter
3 By default Pickaxe works in old style (checks cube 5x5)