### PR TITLE
Performance fixes

### DIFF
--- a/src/main/java/com/oitsjustjose/geolosys/world/ChunkData.java
+++ b/src/main/java/com/oitsjustjose/geolosys/world/ChunkData.java
@@ -34,7 +34,7 @@ public class ChunkData
             }
             if (ModConfig.samples.generateInWater || !isMoist(world, p))
             {
-                world.setBlockState(p, state);
+                world.setBlockState(p, state, 2|16);
             }
         }
     }

--- a/src/main/java/com/oitsjustjose/geolosys/world/StoneGenerator.java
+++ b/src/main/java/com/oitsjustjose/geolosys/world/StoneGenerator.java
@@ -1,5 +1,6 @@
 package com.oitsjustjose.geolosys.world;
 
+import com.google.common.base.Predicate;
 import com.oitsjustjose.geolosys.Geolosys;
 import com.oitsjustjose.geolosys.api.GeolosysAPI;
 import net.minecraft.block.state.IBlockState;
@@ -8,7 +9,6 @@ import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraft.world.gen.IChunkGenerator;
-import net.minecraft.world.gen.feature.WorldGenMinable;
 import net.minecraftforge.fml.common.IWorldGenerator;
 
 import java.util.ArrayList;
@@ -22,7 +22,9 @@ import java.util.Random;
 
 public class StoneGenerator implements IWorldGenerator
 {
+    private static final Predicate<IBlockState> blockStatePredicate = iBlockState -> iBlockState != null && (GeolosysAPI.replacementMats.contains(iBlockState));
     private static ArrayList<StoneGen> stoneSpawnList = new ArrayList<>();
+    private static final String dataID = "geolosysStoneGeneratorPending";
 
     public static void addStoneGen(IBlockState state, int minY, int maxY, int weight)
     {
@@ -33,6 +35,7 @@ public class StoneGenerator implements IWorldGenerator
     @Override
     public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider)
     {
+        ToDoBlocks.getForWorld(world, dataID).processPending(new ChunkPos(chunkX, chunkZ), world, blockStatePredicate);
         if (stoneSpawnList.size() > 0)
         {
             stoneSpawnList.get(random.nextInt(stoneSpawnList.size())).generate(world, random, (chunkX * 16), (chunkZ * 16));
@@ -41,7 +44,7 @@ public class StoneGenerator implements IWorldGenerator
 
     public static class StoneGen
     {
-        WorldGenMinable pluton;
+        WorldGenMinableSafe pluton;
         IBlockState state;
         int minY;
         int maxY;
@@ -50,7 +53,7 @@ public class StoneGenerator implements IWorldGenerator
 
         StoneGen(IBlockState state, int minY, int maxY, int weight)
         {
-            this.pluton = new WorldGenMinable(state, 96, iBlockState -> iBlockState != null && (GeolosysAPI.replacementMats.contains(iBlockState)));
+            this.pluton = new WorldGenMinableSafe(state, 96, blockStatePredicate, dataID);
             this.state = state;
             this.minY = Math.min(minY, maxY);
             this.maxY = Math.max(minY, maxY);

--- a/src/main/java/com/oitsjustjose/geolosys/world/ToDoBlocks.java
+++ b/src/main/java/com/oitsjustjose/geolosys/world/ToDoBlocks.java
@@ -1,0 +1,108 @@
+package com.oitsjustjose.geolosys.world;
+
+import com.google.common.base.Predicate;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.nbt.NBTUtil;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
+import net.minecraft.world.storage.WorldSavedData;
+import net.minecraftforge.common.util.Constants;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Created by Thiakil on 17/06/2018.
+ */
+public class ToDoBlocks extends WorldSavedData {
+	private Map<ChunkPos, Map<BlockPos,IBlockState>> pendingBlocks = new HashMap<>();
+
+	public ToDoBlocks(String name) {
+		super(name);
+	}
+
+	public void storePending(BlockPos pos, IBlockState state){
+		Map<BlockPos,IBlockState> entries = pendingBlocks.computeIfAbsent(new ChunkPos(pos), k->new HashMap<>());
+		entries.put(pos.toImmutable(), state);
+		markDirty();
+	}
+
+	public void processPending(ChunkPos pos, World world, Predicate<IBlockState> predicate){
+		Map<BlockPos,IBlockState> pending = pendingBlocks.get(pos);
+		if (pending != null && !pending.isEmpty()){
+			Iterator<Map.Entry<BlockPos,IBlockState>> iterator = pending.entrySet().iterator();
+			while (iterator.hasNext()){
+				Map.Entry<BlockPos,IBlockState> e = iterator.next();
+				BlockPos blockPos = e.getKey();
+
+				IBlockState state = world.getBlockState(blockPos);
+				if (state.getBlock().isReplaceableOreGen(state, world, blockPos, predicate)) {
+					world.setBlockState(blockPos, e.getValue(), 2|16);
+				}
+				iterator.remove();
+			}
+			if (pending.isEmpty()){
+				pendingBlocks.remove(pos);
+			}
+			markDirty();
+		}
+	}
+
+	@Override
+	public void readFromNBT(NBTTagCompound nbt) {
+		pendingBlocks.clear();
+		for (String key : nbt.getKeySet()){
+			NBTBase val = nbt.getTag(key);
+			if (val instanceof NBTTagList && ((NBTTagList) val).getTagType() == Constants.NBT.TAG_COMPOUND && !val.hasNoTags()) {
+				try {
+					Long asLong = Long.parseLong(key);
+					NBTTagList list = (NBTTagList)val;
+					ChunkPos chunkPos = new ChunkPos((int)(asLong & 4294967295L), (int)((asLong >> 32 )& 4294967295L));
+					Map<BlockPos, IBlockState> entries = new HashMap<>();
+					for (NBTBase b : list){
+						if (b instanceof NBTTagCompound && ((NBTTagCompound) b).hasKey("pos") && ((NBTTagCompound) b).hasKey("state")){
+							NBTTagCompound e = (NBTTagCompound)b;
+							entries.put(NBTUtil.getPosFromTag(e.getCompoundTag("pos")), NBTUtil.readBlockState(e.getCompoundTag("state")));
+						}
+					}
+					if (!entries.isEmpty()){
+						pendingBlocks.put(chunkPos, entries);
+					}
+				} catch (NumberFormatException e){
+					//bad key, carry on
+				}
+			}
+		}
+	}
+
+	@Override
+	public NBTTagCompound writeToNBT(NBTTagCompound compound) {
+		for (Map.Entry<ChunkPos, Map<BlockPos,IBlockState>> chunkEntry : pendingBlocks.entrySet()){
+			if (!chunkEntry.getValue().isEmpty()){
+				NBTTagList chunkEntries = new NBTTagList();
+				compound.setTag(Long.toString(ChunkPos.asLong(chunkEntry.getKey().x, chunkEntry.getKey().z)), chunkEntries);
+				for (Map.Entry<BlockPos,IBlockState> blockEntry : chunkEntry.getValue().entrySet()){
+					NBTTagCompound entry = new NBTTagCompound();
+					entry.setTag("pos", NBTUtil.createPosTag(blockEntry.getKey()));
+					entry.setTag("state", NBTUtil.writeBlockState(new NBTTagCompound(), blockEntry.getValue()));
+					chunkEntries.appendTag(entry);
+				}
+			}
+		}
+		return compound;
+	}
+
+	public static ToDoBlocks getForWorld(World world, String dataID){
+		ToDoBlocks ret = (ToDoBlocks)world.loadData(ToDoBlocks.class, dataID);
+		if (ret == null){
+			ret = new ToDoBlocks(dataID);
+			world.setData(dataID, ret);
+		}
+		return ret;
+	}
+}

--- a/src/main/java/com/oitsjustjose/geolosys/world/WorldGenMinableSafe.java
+++ b/src/main/java/com/oitsjustjose/geolosys/world/WorldGenMinableSafe.java
@@ -1,0 +1,102 @@
+package com.oitsjustjose.geolosys.world;
+
+import com.google.common.base.Predicate;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenerator;
+
+import java.util.Random;
+
+public class WorldGenMinableSafe extends WorldGenerator
+{
+    private final IBlockState oreBlock;
+    /** The number of blocks to generate. */
+    private final int numberOfBlocks;
+    private final Predicate<IBlockState> predicate;
+    private String dataName;
+
+    public WorldGenMinableSafe(IBlockState state, int blockCount, Predicate<IBlockState> p_i45631_3_, String dataName)
+    {
+        this.oreBlock = state;
+        this.numberOfBlocks = blockCount;
+        this.predicate = p_i45631_3_;
+        this.dataName = dataName;
+    }
+
+    public boolean generate(World worldIn, Random rand, BlockPos position)
+    {
+        float f = rand.nextFloat() * (float)Math.PI;
+        double d0 = (double)((float)(position.getX() + 8) + MathHelper.sin(f) * (float)this.numberOfBlocks / 8.0F);
+        double d1 = (double)((float)(position.getX() + 8) - MathHelper.sin(f) * (float)this.numberOfBlocks / 8.0F);
+        double d2 = (double)((float)(position.getZ() + 8) + MathHelper.cos(f) * (float)this.numberOfBlocks / 8.0F);
+        double d3 = (double)((float)(position.getZ() + 8) - MathHelper.cos(f) * (float)this.numberOfBlocks / 8.0F);
+        double d4 = (double)(position.getY() + rand.nextInt(3) - 2);
+        double d5 = (double)(position.getY() + rand.nextInt(3) - 2);
+
+        ToDoBlocks toDoBlocks = ToDoBlocks.getForWorld(worldIn, dataName);
+        ChunkPos thisChunk = new ChunkPos(position);
+
+        for (int i = 0; i < this.numberOfBlocks; ++i)
+        {
+            float f1 = (float)i / (float)this.numberOfBlocks;
+            double d6 = d0 + (d1 - d0) * (double)f1;
+            double d7 = d4 + (d5 - d4) * (double)f1;
+            double d8 = d2 + (d3 - d2) * (double)f1;
+            double d9 = rand.nextDouble() * (double)this.numberOfBlocks / 16.0D;
+            double d10 = (double)(MathHelper.sin((float)Math.PI * f1) + 1.0F) * d9 + 1.0D;
+            double d11 = (double)(MathHelper.sin((float)Math.PI * f1) + 1.0F) * d9 + 1.0D;
+            int j = MathHelper.floor(d6 - d10 / 2.0D);
+            int k = MathHelper.floor(d7 - d11 / 2.0D);
+            int l = MathHelper.floor(d8 - d10 / 2.0D);
+            int i1 = MathHelper.floor(d6 + d10 / 2.0D);
+            int j1 = MathHelper.floor(d7 + d11 / 2.0D);
+            int k1 = MathHelper.floor(d8 + d10 / 2.0D);
+
+            for (int l1 = j; l1 <= i1; ++l1)
+            {
+                double d12 = ((double)l1 + 0.5D - d6) / (d10 / 2.0D);
+
+                if (d12 * d12 < 1.0D)
+                {
+                    for (int i2 = k; i2 <= j1; ++i2)
+                    {
+                        double d13 = ((double)i2 + 0.5D - d7) / (d11 / 2.0D);
+
+                        if (d12 * d12 + d13 * d13 < 1.0D)
+                        {
+                            for (int j2 = l; j2 <= k1; ++j2)
+                            {
+                                double d14 = ((double)j2 + 0.5D - d8) / (d10 / 2.0D);
+
+                                if (d12 * d12 + d13 * d13 + d14 * d14 < 1.0D)
+                                {
+                                    BlockPos blockpos = new BlockPos(l1, i2, j2);
+
+                                    if (isInChunk(thisChunk, blockpos) || worldIn.isChunkGeneratedAt(l1 >> 4, j2 >> 4)) {
+                                        IBlockState state = worldIn.getBlockState(blockpos);
+                                        if (state.getBlock().isReplaceableOreGen(state, worldIn, blockpos, this.predicate)) {
+                                            worldIn.setBlockState(blockpos, this.oreBlock, 2|16);
+                                        }
+                                    } else {
+                                        toDoBlocks.storePending(blockpos, this.oreBlock);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean isInChunk(ChunkPos chunkPos, BlockPos pos){
+        int blockX = pos.getX();
+        int blockZ = pos.getZ();
+        return blockX >= chunkPos.getXStart() && blockX <= chunkPos.getXEnd() && blockZ >= chunkPos.getZStart() && blockZ <= chunkPos.getZEnd();
+    }
+}


### PR DESCRIPTION
1. Fixes the cascading chunk gen.
    - `setBlockState` needs to include `flags 16` , to avoid Observer code from sending updates to adjacent chunks which may not be loaded
    - Any blocks that aren't the current chunk or already generated are saved and queued for later via WorldSavedData
2. Moves the file saving to another thread
    - Might not seem like a big deal, but file IO requires kernel/user space synchronisation which is far more expensive than a thread sync point for executors
    - This could probably be better served by using a WorldSavedData class too, so that the MC system handles when to write it to disk.