### PR TITLE
Possible mitigation for blockstate matching issues

### DIFF
--- a/src/main/java/com/oitsjustjose/geolosys/Geolosys.java
+++ b/src/main/java/com/oitsjustjose/geolosys/Geolosys.java
@@ -1,5 +1,16 @@
 package com.oitsjustjose.geolosys;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import javax.annotation.Nonnull;
+
+import org.apache.logging.log4j.Logger;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.oitsjustjose.geolosys.client.ClientRegistry;
@@ -12,7 +23,11 @@ import com.oitsjustjose.geolosys.common.blocks.BlockSampleVanilla;
 import com.oitsjustjose.geolosys.common.config.ConfigOres;
 import com.oitsjustjose.geolosys.common.config.ConfigParser;
 import com.oitsjustjose.geolosys.common.config.ModConfig;
-import com.oitsjustjose.geolosys.common.items.*;
+import com.oitsjustjose.geolosys.common.items.ItemCluster;
+import com.oitsjustjose.geolosys.common.items.ItemCoal;
+import com.oitsjustjose.geolosys.common.items.ItemFieldManual;
+import com.oitsjustjose.geolosys.common.items.ItemIngot;
+import com.oitsjustjose.geolosys.common.items.ItemProPick;
 import com.oitsjustjose.geolosys.common.util.HelperFunctions;
 import com.oitsjustjose.geolosys.common.util.Recipes;
 import com.oitsjustjose.geolosys.common.world.ChunkData;
@@ -22,6 +37,7 @@ import com.oitsjustjose.geolosys.common.world.VanillaWorldGenOverride;
 import com.oitsjustjose.geolosys.compat.ModMaterials;
 import com.oitsjustjose.geolosys.compat.OreConverter;
 import com.oitsjustjose.geolosys.compat.ie.IECompat;
+
 import net.minecraft.block.BlockStone;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
@@ -37,10 +53,6 @@ import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartedEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
-import org.apache.logging.log4j.Logger;
-
-import javax.annotation.Nonnull;
-import java.io.*;
 
 @Mod(modid = Geolosys.MODID, name = "Geolosys", version = Geolosys.VERSION, acceptedMinecraftVersions = "1.12", dependencies = "after:immersiveengineering@[0.12,);")
 public class Geolosys
@@ -105,15 +117,15 @@ public class Geolosys
         {
             MinecraftForge.EVENT_BUS.register(new OreConverter());
         }
-
+        
         registerGeolosysOreGen();
         registerVanillaOreGen();
     }
 
     @EventHandler
     public void init(FMLInitializationEvent event)
-    {
-        proxy.init(event);
+    {    	
+    	proxy.init(event);
         MinecraftForge.ORE_GEN_BUS.register(new VanillaWorldGenOverride());
 
         if (Loader.isModLoaded("immersiveengineering") && ModConfig.featureControl.enableIECompat)
@@ -244,6 +256,7 @@ public class Geolosys
                 Gson gson = new GsonBuilder().setPrettyPrinting().create();
                 ConfigOres ret = gson.fromJson(json.toString(), ConfigOres.class);
                 ret.validate(configDir);
+                br.close();
                 return ret;
             }
             catch (IOException e)

--- a/src/main/java/com/oitsjustjose/geolosys/common/api/GeolosysAPI.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/api/GeolosysAPI.java
@@ -1,22 +1,28 @@
 package com.oitsjustjose.geolosys.common.api;
 
-import com.google.common.base.Predicate;
-import com.oitsjustjose.geolosys.Geolosys;
-import com.oitsjustjose.geolosys.common.config.ConfigOres;
-import com.oitsjustjose.geolosys.common.config.ModConfig;
-import com.oitsjustjose.geolosys.common.world.OreGenerator;
-import com.oitsjustjose.geolosys.common.world.StoneGenerator;
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.util.math.ChunkPos;
-import net.minecraftforge.common.DimensionManager;
-
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+
+import com.oitsjustjose.geolosys.Geolosys;
+import com.oitsjustjose.geolosys.common.config.ConfigOres;
+import com.oitsjustjose.geolosys.common.config.ModConfig;
+import com.oitsjustjose.geolosys.common.world.OreGenerator;
+import com.oitsjustjose.geolosys.common.world.StoneGenerator;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraftforge.common.DimensionManager;
 
 /**
  * The Geolosys API is intended for use by anyone who wants to tap into all the locations that deposits exist
@@ -29,7 +35,7 @@ public class GeolosysAPI
     // A collection of blocks which Geolosys can replace in generation
     public static ArrayList<IBlockState> replacementMats = new ArrayList<>();
     // A matched pair of IBlockStates whose K:V = block:replacement
-    public static HashMap<IBlockState, Predicate> oreBlocksSpecific = new HashMap<>();
+    public static HashMap<IBlockState, List<IBlockState>> oreBlocksSpecific = new HashMap<>();
     // A collection of blocks to ignore in the OreConverter feature
     public static ArrayList<IBlockState> oreConverterBlacklist = new ArrayList<>();
     // A K:V pair of IBlockStates with their sample sizes
@@ -204,20 +210,20 @@ public class GeolosysAPI
     /**
      * Adds a deposit for Geolosys to handle the generation of.
      *
-     * @param oreBlock        The block you want UNDERGROUND as an ore
-     * @param sampleBlock     The block you want ON THE SURFACE as a sample
-     * @param yMin            The minimum Y level this deposit can generate at
-     * @param yMax            The maximum Y level this deposit can generate at
-     * @param size            The size of the deposit
-     * @param chance          The chance of the deposit generating (higher = more likely)
-     * @param dimBlacklist    An array of dimension numbers in which this deposit cannot generate
-     * @param predicateBlocks A collection of blocks that this entry specifically can replace
+     * @param oreBlock           The block you want UNDERGROUND as an ore
+     * @param sampleBlock        The block you want ON THE SURFACE as a sample
+     * @param yMin               The minimum Y level this deposit can generate at
+     * @param yMax               The maximum Y level this deposit can generate at
+     * @param size               The size of the deposit
+     * @param chance             The chance of the deposit generating (higher = more likely)
+     * @param dimBlacklist       An array of dimension numbers in which this deposit cannot generate
+     * @param blockStateMatchers A collection of blocks that this entry specifically can replace
      */
-    public static void registerMineralDeposit(IBlockState oreBlock, IBlockState sampleBlock, int yMin, int yMax, int size, int chance, int[] dimBlacklist, List<IBlockState> predicateBlocks)
+    public static void registerMineralDeposit(IBlockState oreBlock, IBlockState sampleBlock, int yMin, int yMax, int size, int chance, int[] dimBlacklist, List<IBlockState> blockStateMatchers)
     {
         oreBlocks.put(oreBlock, sampleBlock);
         sampleCounts.put(sampleBlock, size);
-        oreBlocksSpecific.put(oreBlock, iBlockState -> iBlockState != null && (predicateBlocks.contains(iBlockState)));
+        oreBlocksSpecific.put(oreBlock, blockStateMatchers);
         OreGenerator.addOreGen(oreBlock, size, yMin, yMax, chance, dimBlacklist);
     }
 

--- a/src/main/java/com/oitsjustjose/geolosys/common/util/HelperFunctions.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/util/HelperFunctions.java
@@ -63,4 +63,13 @@ public class HelperFunctions
     {
         return new ItemStack(Item.getItemFromBlock(state.getBlock()), 1, state.getBlock().getMetaFromState(state));
     }
+    
+    public static boolean doStatesMatch(IBlockState state1, IBlockState state2)
+    {
+        if (state1.getBlock() == state2.getBlock() && state1.getBlock().getMetaFromState(state1) == state2.getBlock().getMetaFromState(state2))
+        {
+        	return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/oitsjustjose/geolosys/common/world/StoneGenerator.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/world/StoneGenerator.java
@@ -1,9 +1,12 @@
 package com.oitsjustjose.geolosys.common.world;
 
-import com.google.common.base.Predicate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
 import com.oitsjustjose.geolosys.Geolosys;
 import com.oitsjustjose.geolosys.common.api.GeolosysAPI;
-import com.sun.org.apache.bcel.internal.generic.LASTORE;
+
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
@@ -13,9 +16,6 @@ import net.minecraft.world.gen.IChunkGenerator;
 import net.minecraftforge.common.ForgeModContainer;
 import net.minecraftforge.fml.common.IWorldGenerator;
 
-import java.util.ArrayList;
-import java.util.Random;
-
 /**
  * A modified version of:
  * https://github.com/BluSunrize/ImmersiveEngineering/blob/master/src/main/java/blusunrize/immersiveengineering/common/world/IEWorldGen.java
@@ -24,7 +24,7 @@ import java.util.Random;
 
 public class StoneGenerator implements IWorldGenerator
 {
-    private static final Predicate<IBlockState> blockStatePredicate = iBlockState -> iBlockState != null && (GeolosysAPI.replacementMats.contains(iBlockState));
+    private static final List<IBlockState> blockStateMatchers = GeolosysAPI.replacementMats;
     private static final String dataID = "geolosysStoneGeneratorPending";
     private static ArrayList<StoneGen> stoneSpawnList = new ArrayList<>();
 
@@ -37,7 +37,7 @@ public class StoneGenerator implements IWorldGenerator
     @Override
     public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider)
     {
-        ToDoBlocks.getForWorld(world, dataID).processPending(new ChunkPos(chunkX, chunkZ), world, blockStatePredicate);
+        ToDoBlocks.getForWorld(world, dataID).processPending(new ChunkPos(chunkX, chunkZ), world, blockStateMatchers);
         if (stoneSpawnList.size() > 0)
         {
             stoneSpawnList.get(random.nextInt(stoneSpawnList.size())).generate(world, random, (chunkX * 16), (chunkZ * 16));
@@ -55,7 +55,7 @@ public class StoneGenerator implements IWorldGenerator
 
         StoneGen(IBlockState state, int minY, int maxY, int weight)
         {
-            this.pluton = new WorldGenMinableSafe(state, 96, blockStatePredicate, dataID);
+            this.pluton = new WorldGenMinableSafe(state, 96, blockStateMatchers, dataID);
             this.state = state;
             this.minY = Math.min(minY, maxY);
             this.maxY = Math.max(minY, maxY);

--- a/src/main/java/com/oitsjustjose/geolosys/common/world/ToDoBlocks.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/world/ToDoBlocks.java
@@ -1,6 +1,10 @@
 package com.oitsjustjose.geolosys.common.world;
 
-import com.google.common.base.Predicate;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
@@ -12,12 +16,9 @@ import net.minecraft.world.World;
 import net.minecraft.world.storage.WorldSavedData;
 import net.minecraftforge.common.util.Constants;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
 /**
  * Created by Thiakil on 17/06/2018.
+ * Minor edits by PersonTheCat
  */
 public class ToDoBlocks extends WorldSavedData
 {
@@ -46,7 +47,7 @@ public class ToDoBlocks extends WorldSavedData
         markDirty();
     }
 
-    public void processPending(ChunkPos pos, World world, Predicate<IBlockState> predicate)
+    public void processPending(ChunkPos pos, World world, List<IBlockState> matchers)
     {
         Map<BlockPos, IBlockState> pending = pendingBlocks.get(pos);
         if (pending != null && !pending.isEmpty())
@@ -58,7 +59,7 @@ public class ToDoBlocks extends WorldSavedData
                 BlockPos blockPos = e.getKey();
 
                 IBlockState state = world.getBlockState(blockPos);
-                if (state.getBlock().isReplaceableOreGen(state, world, blockPos, predicate))
+                if (state != null && matchers.contains(state))
                 {
                     world.setBlockState(blockPos, e.getValue(), 2 | 16);
                 }

--- a/src/main/java/com/oitsjustjose/geolosys/common/world/WorldGenMinableSafe.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/world/WorldGenMinableSafe.java
@@ -1,14 +1,16 @@
 package com.oitsjustjose.geolosys.common.world;
 
-import com.google.common.base.Predicate;
+import java.util.List;
+import java.util.Random;
+
+import com.oitsjustjose.geolosys.common.util.HelperFunctions;
+
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.feature.WorldGenerator;
-
-import java.util.Random;
 
 public class WorldGenMinableSafe extends WorldGenerator
 {
@@ -17,14 +19,14 @@ public class WorldGenMinableSafe extends WorldGenerator
      * The number of blocks to generate.
      */
     private final int numberOfBlocks;
-    private final Predicate<IBlockState> predicate;
+    private final List<IBlockState> matchers;
     private String dataName;
 
-    public WorldGenMinableSafe(IBlockState state, int blockCount, Predicate<IBlockState> p_i45631_3_, String dataName)
+    public WorldGenMinableSafe(IBlockState state, int blockCount, List<IBlockState> matchers, String dataName)
     {
         this.oreBlock = state;
         this.numberOfBlocks = blockCount;
-        this.predicate = p_i45631_3_;
+        this.matchers = matchers;
         this.dataName = dataName;
     }
 
@@ -87,9 +89,16 @@ public class WorldGenMinableSafe extends WorldGenerator
                                     if (isInChunk(thisChunk, blockpos) || worldIn.isChunkGeneratedAt(l1 >> 4, j2 >> 4))
                                     {
                                         IBlockState state = worldIn.getBlockState(blockpos);
-                                        if (state.getBlock().isReplaceableOreGen(state, worldIn, blockpos, this.predicate))
+                                        if (state != null)
                                         {
-                                            worldIn.setBlockState(blockpos, this.oreBlock, 2 | 16);
+                                        	for (IBlockState iBlockState : matchers)
+                                        	{
+                                        		if (HelperFunctions.doStatesMatch(iBlockState, state))
+                                        		{
+                                        			worldIn.setBlockState(blockpos, this.oreBlock, 2 | 16);
+                                        			break;
+                                        		}
+                                        	}
                                         }
                                     }
                                     else


### PR DESCRIPTION
Replaces all instances of `Predicate<IBlockState>` with `List<IBlockState>`. Used for direct validation of blockstate parity. This should not be necessary at all, but for some reason, it seems to work more consistently. Could (but likely does not) break functionality with some rare, modded blocks, and thus, depending on your preferences, may not be an ideal solution. 

Using the public release of 2.0, I quickly noticed a few veins that did not generate in the correct blocks. Because vein placement appears to be slightly inconsistent between world seeds, I was not able to verify that individual locations had been corrected by these changes. I could, however, locate several locations that did work correctly, while not finding any that were incorrect after some testing (approx. 15 minutes). Based on previous tests, there may be more veins out there that either don't match correctly or are somehow getting replaced by OreConverter. While I feel confident that these veins are not being spawned by OSV, as its generation is entirely disabled by default in the presence of Geolosys, I would have to agree that OSV could potentially be at fault here. I just don't see how. 

Let me know what you think. Thanks for listening to and responding to my repeated spam. 

-Cat