### PR TITLE
Add config to enable/disable AE2 compat

### DIFF
--- a/src/main/java/com/oitsjustjose/geolosys/common/blocks/BlockOreVanilla.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/blocks/BlockOreVanilla.java
@@ -84,7 +84,7 @@ public class BlockOreVanilla extends Block
         Random random = new Random();
         int rng = random.nextInt(25);
         // AE Compatibility
-        if (OreDictionary.doesOreNameExist("oreCertusQuartz") && OreDictionary.getOres("oreCertusQuartz").size() > 0)
+        if (ModConfig.compat.enableAE2Compat && OreDictionary.doesOreNameExist("oreCertusQuartz") && OreDictionary.getOres("oreCertusQuartz").size() > 0)
         {
             if (rng < 7)
             {

--- a/src/main/java/com/oitsjustjose/geolosys/common/config/ModConfig.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/config/ModConfig.java
@@ -171,6 +171,10 @@ public class ModConfig
         @Config.RequiresMcRestart
         public boolean enableIECompat = true;
 
+        @Config.Name("Enable AE2 Integration")
+        @Config.RequiresMcRestart
+        public boolean enableAE2Compat = true;
+
         @Config.Name("IE Excavation Recipes to Remove")
         @Config.Comment("If Enable IE Integration is True, then I register my own excavation \"recipes\","
                 + " leading to potential redundancy. This config is a list of strings to remove from IE")

--- a/src/main/java/com/oitsjustjose/geolosys/compat/CompatLoader.java
+++ b/src/main/java/com/oitsjustjose/geolosys/compat/CompatLoader.java
@@ -36,7 +36,7 @@ public class CompatLoader
             this.logger.info("Loading Extra Utilities compatibility");
             MinecraftForge.EVENT_BUS.register(new ExUtilsCompat());
         }
-        if (Loader.isModLoaded("appliedenergistics2"))
+        if (Loader.isModLoaded("appliedenergistics2") && ModConfig.compat.enableAE2Compat)
         {
             this.logger.info("Loading Applied Energistics compatibility");
             MinecraftForge.EVENT_BUS.register(new AppEngCompat());

--- a/src/main/java/com/oitsjustjose/geolosys/compat/IECompat.java
+++ b/src/main/java/com/oitsjustjose/geolosys/compat/IECompat.java
@@ -25,7 +25,7 @@ public class IECompat
     public static void init()
     {
         OreDictionary.registerOre("clumpCoal", Items.COAL);
-        if (ModMaterials.AE_MATERIAL != null)
+        if (ModConfig.compat.enableAE2Compat && ModMaterials.AE_MATERIAL != null)
         {
             OreDictionary.registerOre("crystalCertusQuartzCharged", new ItemStack(ModMaterials.AE_MATERIAL, 1, 1));
         }
@@ -153,7 +153,7 @@ public class IECompat
         crusherRecipe = crusherRecipe.addToSecondaryOutput(new ItemStack(Items.QUARTZ), .2F);
         crusherRecipe = crusherRecipe.addToSecondaryOutput(new ItemStack(Items.QUARTZ), .2F);
 
-        if (ModMaterials.AE_MATERIAL != null)
+        if (ModConfig.compat.enableAE2Compat && ModMaterials.AE_MATERIAL != null)
         {
             crusherRecipe = crusherRecipe.addToSecondaryOutput(new ItemStack(ModMaterials.AE_MATERIAL, 1, 0), .3F);
             crusherRecipe = crusherRecipe.addToSecondaryOutput(new ItemStack(ModMaterials.AE_MATERIAL, 1, 1), .12F);


### PR DESCRIPTION
Added a config flag to enable/disable Applied Energistics 2 (AE2) compatibility in case it's desirable to not have quartz blocks drop charged/uncharged certus quartz.