### PR TITLE
BlameJared maven should use https and subdomain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ repositories {
     // IE
     maven {
     	name 'jared maven'
-    	url 'http://blamejared.com/maven'
+    	url 'https://maven.blamejared.com/'
 	}
     // UBC 
     maven {


### PR DESCRIPTION
While this isn't an issue right now, if I ever need to move the maven folder, or need to direct the subdomain to a different server, this will be an issue.

http -> https is just an upgrade