### PR TITLE
Disable pro_pick recipe when it is disabled

### DIFF
--- a/src/main/resources/assets/geolosys/recipes/pro_pick.json
+++ b/src/main/resources/assets/geolosys/recipes/pro_pick.json
@@ -1,4 +1,10 @@
 {
+  "conditions": [
+    {
+      "type": "minecraft:item_exists",
+      "item": "geolosys:pro_pick"
+    }
+  ],
   "type": "minecraft:crafting_shaped",
   "pattern": [
     "IIB",


### PR DESCRIPTION
Forge blows logs with error due to item used in recipe but being not registered when it is disabled in configs:
```
[Server thread/ERROR] [FML]: Parsing error loading recipe geolosys:pro_pick
com.google.gson.JsonSyntaxException: Unknown item 'geolosys:pro_pick'
...
```