### PR TITLE
Fixed #269 by creating a new ore-remover implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,11 +58,17 @@ dependencies {
 
 repositories {
     maven { url 'https://maven.blamejared.com' }
+    repositories {
+        maven {
+            url "https://www.cursemaven.com"
+        }
+    }
 }
 
 dependencies {
     compileOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}:api")
     runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
+    implementation fg.deobf("curse.maven:worldstripper-250603:3334904")
 }
 
 // Example for how to get properties into the manifest for reading by the runtime..

--- a/src/main/java/com/oitsjustjose/geolosys/common/world/OreRemover.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/world/OreRemover.java
@@ -1,27 +1,65 @@
 package com.oitsjustjose.geolosys.common.world;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import java.util.function.Supplier;
 
+import com.oitsjustjose.geolosys.Geolosys;
+import com.oitsjustjose.geolosys.common.config.CommonConfig;
+import com.oitsjustjose.geolosys.common.world.feature.FeatureUtils;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.world.gen.GenerationStage.Decoration;
-import net.minecraft.world.gen.feature.ConfiguredFeature;
-import net.minecraft.world.gen.feature.DecoratedFeatureConfig;
-import net.minecraft.world.gen.feature.IFeatureConfig;
-import net.minecraft.world.gen.feature.OreFeatureConfig;
-import net.minecraft.world.gen.feature.ReplaceBlockConfig;
+import net.minecraft.world.gen.feature.*;
 import net.minecraftforge.common.world.BiomeGenerationSettingsBuilder;
 
 public class OreRemover {
-    private static List<Block> toRm = Arrays.asList(Blocks.IRON_ORE, Blocks.COAL_ORE, Blocks.LAPIS_ORE,
-            Blocks.DIAMOND_ORE, Blocks.EMERALD_ORE, Blocks.GOLD_ORE, Blocks.REDSTONE_ORE, Blocks.NETHER_QUARTZ_ORE,
-            Blocks.NETHER_GOLD_ORE, Blocks.ANCIENT_DEBRIS, Blocks.DIORITE, Blocks.ANDESITE, Blocks.GRANITE,
-            Blocks.INFESTED_STONE);
 
+    private static List<Block> toRm = Arrays.asList(
+            Blocks.IRON_ORE, Blocks.COAL_ORE, Blocks.LAPIS_ORE,
+            Blocks.DIAMOND_ORE, Blocks.EMERALD_ORE, Blocks.GOLD_ORE,
+            Blocks.REDSTONE_ORE, Blocks.NETHER_QUARTZ_ORE, Blocks.NETHER_GOLD_ORE,
+            Blocks.ANCIENT_DEBRIS, Blocks.DIORITE, Blocks.ANDESITE, Blocks.GRANITE,
+            Blocks.INFESTED_STONE
+    );
+
+    // List of removed features
+    public static List<Supplier<ConfiguredFeature<?, ?>>> removed = new LinkedList<>();
+
+    // Validates, removes and logs each feature
+    private static void featureRemover(Block targetBlock, Supplier<ConfiguredFeature<?, ?>> targetFeature) {
+        if (targetBlock != null) {
+            if (toRm.contains(targetBlock)) {
+                removed.add(targetFeature);
+                if (CommonConfig.DEBUG_WORLD_GEN.get()) {
+                    Geolosys.getInstance().LOGGER.info(targetBlock.getRegistryName() + " : " + targetFeature.get().feature.getRegistryName() + " removed");
+                }
+            }
+        }
+    }
+
+    // Filters the features before sending em to the featureRemover()
+    public static List<Supplier<ConfiguredFeature<?, ?>>> filterFeatures(List<Supplier<ConfiguredFeature<?, ?>>> features) {
+        for (Supplier<ConfiguredFeature<?, ?>> feature : features) {
+            Block targetBlock = null;
+            ConfiguredFeature<?, ?> targetFeature = FeatureUtils.getFeature(feature.get());
+
+            if (targetFeature.feature instanceof OreFeature || targetFeature.feature instanceof NoExposedOreFeature) {
+                // Normal ores
+                OreFeatureConfig config = (OreFeatureConfig) targetFeature.config;
+                targetBlock = config.state.getBlock();
+                featureRemover(targetBlock, feature);
+            } else if (targetFeature.feature instanceof ReplaceBlockFeature) {
+                // Emeralds
+                ReplaceBlockConfig config = (ReplaceBlockConfig) targetFeature.config;
+                targetBlock = config.state.getBlock();
+                featureRemover(targetBlock, feature);
+            }
+
+        }
+        return removed;
+    }
+
+    // Not used anymore, you may remove
     public static int process(BiomeGenerationSettingsBuilder settings) {
         Collection<Supplier<ConfiguredFeature<?, ?>>> toKeep = new ArrayList<Supplier<ConfiguredFeature<?, ?>>>();
         int total = 0;

--- a/src/main/java/com/oitsjustjose/geolosys/common/world/PlutonRegistry.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/world/PlutonRegistry.java
@@ -1,6 +1,8 @@
 package com.oitsjustjose.geolosys.common.world;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Random;
 
 import com.oitsjustjose.geolosys.Geolosys;
@@ -9,6 +11,7 @@ import com.oitsjustjose.geolosys.api.world.DepositMultiOreBiomeRestricted;
 import com.oitsjustjose.geolosys.api.world.DepositStone;
 import com.oitsjustjose.geolosys.api.world.IDeposit;
 import com.oitsjustjose.geolosys.common.config.CommonConfig;
+import com.oitsjustjose.geolosys.common.world.feature.FeatureUtils;
 import com.oitsjustjose.geolosys.common.world.feature.PlutonOreFeature;
 import com.oitsjustjose.geolosys.common.world.feature.PlutonStoneFeature;
 
@@ -108,16 +111,20 @@ public class PlutonRegistry {
         return null;
     }
 
+    // Collects UNDERGROUND_ORES & UNDERGROUND_DECORATION to make it easier to iterate
+    private static final List<GenerationStage.Decoration> decorations = new LinkedList<>(); static {
+        decorations.add(GenerationStage.Decoration.UNDERGROUND_ORES);
+        decorations.add(GenerationStage.Decoration.UNDERGROUND_DECORATION);
+    }
+
     @SubscribeEvent
     public void onBiomesLoaded(BiomeLoadingEvent evt) {
         BiomeGenerationSettingsBuilder settings = evt.getGeneration();
 
+        // Removes vanilla ores
         if (CommonConfig.REMOVE_VANILLA_ORES.get()) {
-            int removed = OreRemover.process(settings);
-            // Notify the user of the removal if debug mode is on
-            if (CommonConfig.DEBUG_WORLD_GEN.get()) {
-                Geolosys.getInstance().LOGGER.info("Removing {} ore generation(s) from biome {}", removed,
-                        evt.getName());
+            for (GenerationStage.Decoration deco : decorations) {
+                FeatureUtils.destroyFeature(settings.getFeatures(deco), OreRemover.filterFeatures(settings.getFeatures(deco)));
             }
         }
 

--- a/src/main/java/com/oitsjustjose/geolosys/common/world/feature/FeatureUtils.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/world/feature/FeatureUtils.java
@@ -1,7 +1,9 @@
 package com.oitsjustjose.geolosys.common.world.feature;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Random;
+import java.util.function.Supplier;
 
 import com.oitsjustjose.geolosys.api.BlockPosDim;
 import com.oitsjustjose.geolosys.api.world.IDeposit;
@@ -15,6 +17,9 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.IWorld;
+import net.minecraft.world.gen.feature.ConfiguredFeature;
+import net.minecraft.world.gen.feature.DecoratedFeature;
+import net.minecraft.world.gen.feature.DecoratedFeatureConfig;
 
 public class FeatureUtils {
 
@@ -30,6 +35,22 @@ public class FeatureUtils {
         int blockZ = pos.getZ();
         return blockX >= chunkPos.getXStart() && blockX <= chunkPos.getXEnd() && blockZ >= chunkPos.getZStart()
                 && blockZ <= chunkPos.getZEnd();
+    }
+
+    public static ConfiguredFeature<?, ?> getFeature(ConfiguredFeature<?, ?> feature) {
+        ConfiguredFeature<?, ?> currentFeature = feature;
+        if (currentFeature.feature instanceof DecoratedFeature) {
+            do {
+                currentFeature = ((DecoratedFeatureConfig) currentFeature.getConfig()).feature.get();
+            } while (currentFeature.feature instanceof DecoratedFeature);
+        }
+        return currentFeature;
+    }
+
+    public static void destroyFeature(List<Supplier<ConfiguredFeature<?, ?>>> features, List<Supplier<ConfiguredFeature<?, ?>>> destroy) {
+        for (Supplier<ConfiguredFeature<?, ?>> feature : destroy) {
+            features.remove(feature);
+        }
     }
 
     public static boolean generateDense(IWorld world, BlockPos pos, Random rand, IDeposit pluton,


### PR DESCRIPTION
I saw your tweet and was intrigued by the issue and I figured out where the issue was in 2 minutes from looking at you're source code. I also have a ore mod named [Ore-Tweaker](https://www.curseforge.com/minecraft/mc-mods/ore-tweaker) ([Source](https://github.com/EwyBoy/OreTweaker)) that also allows users to remove ores.  

By the looks of it, **Geolosys** ends up adding way to many features back into the `BiomeGenerationSettingsBuilder` that results in  essentially creating something I would call an _"amplified biome feature world"_. It is not only the lakes that are plentiful. Pretty much all world gen features picked up by  **Geolosys** is amplified by a lot. It is just that lakes are easy to spot. The world will also contain much more Lava lakes etc.

I implemented something close to the system I am using for [Ore-Tweaker](https://github.com/EwyBoy/OreTweaker/blob/master/src/main/java/com/ewyboy/oretweaker/tweaking/construction/OreDeconstruction.java) to remove ores. It subtracts from the `BiomeGenerationSettingsBuilder` rather then adds inn and I can assure you that it is not removing to many features 😉

I kept your original code so that if you want to implement it in you're own way. The debugging has changed and moved a bit into `featureRemover()` and I tried to stay true to how the mod originally worked.

Also added [World-Stripper](https://www.curseforge.com/minecraft/mc-mods/world-stripper) ([Source](https://github.com/EwyBoy/World-Stripper)) using [CurseMaven](https://www.cursemaven.com/) to easy debug that I did not mess anything up.

Before:
![2021-06-07_11 40 03](https://user-images.githubusercontent.com/5883716/121006041-bcb30900-c790-11eb-92aa-cb643ddb879c.png)

After:
![2021-06-07_12 18 37](https://user-images.githubusercontent.com/5883716/121006090-c9cff800-c790-11eb-9eaf-dce3e74487ce.png)

All ores are still gone with my ore removing implementation:
![2021-06-07_12 34 17](https://user-images.githubusercontent.com/5883716/121006196-e835f380-c790-11eb-9745-76a2910abe31.png)

Also in nether (although you might wanna add `Magma Block` & `Blackstone` to remove list):
![2021-06-07_12 36 06](https://user-images.githubusercontent.com/5883716/121006234-f08e2e80-c790-11eb-87eb-903f742a51ca.png)
