### PR TITLE
Fix #303

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
-mod_version=7.0.4
+mod_version=7.0.5
 game_version=1.18.2
 forge_version=40.0.12
 

--- a/src/main/java/com/oitsjustjose/geolosys/common/world/feature/DepositFeature.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/world/feature/DepositFeature.java
@@ -75,7 +75,7 @@ public class DepositFeature extends Feature<NoneFeatureConfiguration> {
         ChunkPos cp = new ChunkPos(origin);
         /* Filter out only pending blocks for *this* chunk */
         Map<BlockPos, BlockState> forThisChunk = cap.getPendingBlocks(cp);
-        forThisChunk.forEach((pos, state) -> level.setBlock(pos, state, 2 | 16));
+        forThisChunk.forEach((pos, state) -> FeatureUtils.tryPlaceBlock(level, cp, pos, state, cap));
         forThisChunk.forEach((pos, state) -> cap.removePendingBlock(pos, state));
         return forThisChunk.size() > 0;
     }

--- a/src/main/java/com/oitsjustjose/geolosys/common/world/feature/FeatureUtils.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/world/feature/FeatureUtils.java
@@ -1,16 +1,50 @@
 package com.oitsjustjose.geolosys.common.world.feature;
 
+import com.oitsjustjose.geolosys.Geolosys;
 import com.oitsjustjose.geolosys.common.world.capability.IDepositCapability;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.SectionPos;
+import net.minecraft.server.level.WorldGenRegion;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 
 public class FeatureUtils {
+    private static boolean ensureCanWriteNoThrow(WorldGenLevel level, BlockPos pos)
+    {
+        if (level instanceof WorldGenRegion region)
+        {
+            ChunkPos center = region.getCenter();
+            int i = SectionPos.blockToSectionCoord(pos.getX());
+            int j = SectionPos.blockToSectionCoord(pos.getZ());
+            int k = Math.abs(center.x - i);
+            int l = Math.abs(center.z - j);
+            // writeRadiusCutoff is not accessible, so use a constant 1 for 3x3 generation.
+            if (k > 1 || l > 1)
+            {
+                return false;
+            }
+            return true;
+        }
+        else
+        {
+            // All feature levels *should* be WorldGenRegions (this has not thrown yet)
+            Geolosys.getInstance().LOGGER.error("level was not WorldGenRegion");
+            return false;
+        }
+    }
+    
     public static boolean tryPlaceBlock(WorldGenLevel level, ChunkPos chunk, BlockPos pos, BlockState state,
             IDepositCapability cap) {
+
+        if(!ensureCanWriteNoThrow(level, pos))
+        {
+            cap.putPendingBlock(new BlockPos(pos), state);
+            return false;
+        }
+
         if (!level.setBlock(pos, state, 2 | 16)) {
             cap.putPendingBlock(new BlockPos(pos), state);
             return false;


### PR DESCRIPTION
Somewhat of a temporary fix - for robustness, the generation algorithm for deposits should probably be changed to stay inside their 3x3 generation area?

Regardless, error no longer occurs and generation appears to be sane.