### PR TITLE
Remove OnlyIn and rework registration

### DIFF
--- a/src/main/java/com/oitsjustjose/geolosys/Geolosys.java
+++ b/src/main/java/com/oitsjustjose/geolosys/Geolosys.java
@@ -10,6 +10,7 @@ import com.oitsjustjose.geolosys.capability.world.IChunkGennedCapability;
 import com.oitsjustjose.geolosys.client.ClientProxy;
 import com.oitsjustjose.geolosys.client.patchouli.processors.PatronProcessor;
 import com.oitsjustjose.geolosys.client.render.Cutouts;
+import com.oitsjustjose.geolosys.client.render.GeolosysClient;
 import com.oitsjustjose.geolosys.common.CommonProxy;
 import com.oitsjustjose.geolosys.common.config.ClientConfig;
 import com.oitsjustjose.geolosys.common.config.CommonConfig;
@@ -19,22 +20,15 @@ import com.oitsjustjose.geolosys.common.data.modifiers.QuartzDropModifier;
 import com.oitsjustjose.geolosys.common.data.modifiers.SulfurDropModifier;
 import com.oitsjustjose.geolosys.common.data.modifiers.YelloriumDropModifier;
 import com.oitsjustjose.geolosys.common.event.ManualGifting;
+import com.oitsjustjose.geolosys.common.items.Types;
 import com.oitsjustjose.geolosys.common.utils.Constants;
 import com.oitsjustjose.geolosys.common.world.GeolosysFeatures;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
-
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
@@ -44,7 +38,7 @@ import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.RegistryEvent;
-import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+import net.minecraftforge.event.furnace.FurnaceFuelBurnTimeEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.DistExecutor;
@@ -55,6 +49,9 @@ import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLPaths;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 
 @Mod(Constants.MODID)
 public class Geolosys {
@@ -67,8 +64,13 @@ public class Geolosys {
 
         // Register the setup method for modloading
         IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
+
+        Registry.register(bus);
+
         bus.addListener(this::setup);
         bus.addListener(this::clientSetup);
+
+        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, ()->GeolosysClient::setup);
 
         MinecraftForge.EVENT_BUS.register(this);
         MinecraftForge.EVENT_BUS.register(new ManualGifting());
@@ -203,18 +205,11 @@ public class Geolosys {
     }
 
     @SubscribeEvent
-    @OnlyIn(Dist.CLIENT)
-    public void onHover(ItemTooltipEvent event) {
-        if (!ClientConfig.ENABLE_TAG_DEBUG.get()) {
-            return;
-        }
-
-        Minecraft mc = Minecraft.getInstance();
-
-        if (mc.options.advancedItemTooltips) {
-            event.getItemStack().getTags().forEach(x -> {
-                event.getToolTip().add(new TextComponent("\u00A78#" + x.location() + "\u00A7r"));
-            });
+    public void onFuelRegistry(FurnaceFuelBurnTimeEvent fuelBurnoutEvent) {
+        for (Types.Coals c : Types.Coals.values()) {
+            if (fuelBurnoutEvent.getItemStack().getItem().equals(c.getItem())) {
+                fuelBurnoutEvent.setBurnTime(c.getBurnTime() * 200);
+            }
         }
     }
 

--- a/src/main/java/com/oitsjustjose/geolosys/Geolosys.java
+++ b/src/main/java/com/oitsjustjose/geolosys/Geolosys.java
@@ -10,7 +10,7 @@ import com.oitsjustjose.geolosys.capability.world.IChunkGennedCapability;
 import com.oitsjustjose.geolosys.client.ClientProxy;
 import com.oitsjustjose.geolosys.client.patchouli.processors.PatronProcessor;
 import com.oitsjustjose.geolosys.client.render.Cutouts;
-import com.oitsjustjose.geolosys.client.render.GeolosysClient;
+import com.oitsjustjose.geolosys.client.GeolosysClient;
 import com.oitsjustjose.geolosys.common.CommonProxy;
 import com.oitsjustjose.geolosys.common.config.ClientConfig;
 import com.oitsjustjose.geolosys.common.config.CommonConfig;

--- a/src/main/java/com/oitsjustjose/geolosys/client/ClientProxy.java
+++ b/src/main/java/com/oitsjustjose/geolosys/client/ClientProxy.java
@@ -1,5 +1,7 @@
 package com.oitsjustjose.geolosys.client;
 
+import com.oitsjustjose.geolosys.client.network.PacketStackClientSurface;
+import com.oitsjustjose.geolosys.client.network.PacketStackClientUnderground;
 import com.oitsjustjose.geolosys.common.CommonProxy;
 import com.oitsjustjose.geolosys.common.network.PacketHelpers;
 import com.oitsjustjose.geolosys.common.network.PacketStackSurface;
@@ -16,10 +18,10 @@ import java.util.HashSet;
 public class ClientProxy extends CommonProxy {
     public void init() {
         CommonProxy.networkManager.networkWrapper.registerMessage(CommonProxy.discriminator++, PacketStackSurface.class,
-                PacketStackSurface::encode, PacketStackSurface::decode, PacketStackSurface::handleClient);
+                PacketStackSurface::encode, PacketStackSurface::decode, PacketStackClientSurface::handleClient);
         CommonProxy.networkManager.networkWrapper.registerMessage(CommonProxy.discriminator++,
                 PacketStackUnderground.class, PacketStackUnderground::encode, PacketStackUnderground::decode,
-                PacketStackUnderground::handleClient);
+                PacketStackClientUnderground::handleClient);
     }
 
     @Override

--- a/src/main/java/com/oitsjustjose/geolosys/client/GeolosysClient.java
+++ b/src/main/java/com/oitsjustjose/geolosys/client/GeolosysClient.java
@@ -1,5 +1,6 @@
-package com.oitsjustjose.geolosys.client.render;
+package com.oitsjustjose.geolosys.client;
 
+import com.oitsjustjose.geolosys.client.render.ProPickOverlay;
 import com.oitsjustjose.geolosys.common.config.ClientConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.TextComponent;
@@ -14,7 +15,7 @@ public class GeolosysClient {
     }
 
     @SubscribeEvent
-    public void onHover(ItemTooltipEvent event) {
+    public static void onHover(ItemTooltipEvent event) {
         if (!ClientConfig.ENABLE_TAG_DEBUG.get()) {
             return;
         }

--- a/src/main/java/com/oitsjustjose/geolosys/client/network/PacketStackClientSurface.java
+++ b/src/main/java/com/oitsjustjose/geolosys/client/network/PacketStackClientSurface.java
@@ -1,0 +1,29 @@
+package com.oitsjustjose.geolosys.client.network;
+
+import com.oitsjustjose.geolosys.common.network.PacketHelpers;
+import com.oitsjustjose.geolosys.common.network.PacketStackSurface;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class PacketStackClientSurface {
+    public static void handleClient(PacketStackSurface msg, Supplier<NetworkEvent.Context> context) {
+        if (context.get().getDirection().getReceptionSide() == LogicalSide.CLIENT) {
+            context.get().enqueueWork(() -> {
+                Minecraft mc = Minecraft.getInstance();
+                sendProspectingMessage(mc.player, PacketHelpers.messagify(msg.blocks));
+            });
+        }
+        context.get().setPacketHandled(true);
+    }
+
+    private static void sendProspectingMessage(Player player, Object... messageDecorators) {
+        TranslatableComponent msg = new TranslatableComponent("geolosys.pro_pick.tooltip.found_surface",
+                messageDecorators);
+        player.displayClientMessage(msg, true);
+    }
+}

--- a/src/main/java/com/oitsjustjose/geolosys/client/network/PacketStackClientUnderground.java
+++ b/src/main/java/com/oitsjustjose/geolosys/client/network/PacketStackClientUnderground.java
@@ -1,0 +1,29 @@
+package com.oitsjustjose.geolosys.client.network;
+
+import com.oitsjustjose.geolosys.common.network.PacketHelpers;
+import com.oitsjustjose.geolosys.common.network.PacketStackUnderground;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class PacketStackClientUnderground {
+    public static void handleClient(PacketStackUnderground msg, Supplier<NetworkEvent.Context> context) {
+        if (context.get().getDirection().getReceptionSide() == LogicalSide.CLIENT) {
+            context.get().enqueueWork(() -> {
+                Minecraft mc = Minecraft.getInstance();
+                sendProspectingMessage(mc.player, PacketHelpers.messagify(msg.blocks), msg.direction);
+            });
+        }
+        context.get().setPacketHandled(true);
+    }
+
+    private static void sendProspectingMessage(LocalPlayer player, Object... messageDecorators) {
+        TranslatableComponent msg = new TranslatableComponent("geolosys.pro_pick.tooltip.found",
+                messageDecorators);
+        player.displayClientMessage(msg, true);
+    }
+}

--- a/src/main/java/com/oitsjustjose/geolosys/client/render/BlockColorInit.java
+++ b/src/main/java/com/oitsjustjose/geolosys/client/render/BlockColorInit.java
@@ -23,10 +23,10 @@ public class BlockColorInit {
 
         blockColors.register((unknown, lightReader, pos, unknown2) -> lightReader != null && pos != null
                 ? BiomeColors.getAverageGrassColor(lightReader, pos)
-                : GrassColor.get(0.5D, 1.0D), Registry.PEAT);
+                : GrassColor.get(0.5D, 1.0D), Registry.PEAT.get());
         blockColors.register((unknown, lightReader, pos, unknown2) -> lightReader != null && pos != null
                 ? BiomeColors.getAverageGrassColor(lightReader, pos)
-                : GrassColor.get(0.5D, 1.0D), Registry.RHODODENDRON);
+                : GrassColor.get(0.5D, 1.0D), Registry.RHODODENDRON.get());
 
     }
 
@@ -41,9 +41,7 @@ public class BlockColorInit {
             return blockColors.getColor(state, null, null, tintIndex);
         };
 
-        if (itemBlockColourHandler != null) {
-            itemColors.register(itemBlockColourHandler, Registry.PEAT);
-            itemColors.register(itemBlockColourHandler, Registry.RHODODENDRON);
-        }
+        itemColors.register(itemBlockColourHandler, Registry.PEAT.get());
+        itemColors.register(itemBlockColourHandler, Registry.RHODODENDRON.get());
     }
 }

--- a/src/main/java/com/oitsjustjose/geolosys/client/render/Cutouts.java
+++ b/src/main/java/com/oitsjustjose/geolosys/client/render/Cutouts.java
@@ -7,7 +7,7 @@ import net.minecraft.client.renderer.RenderType;
 
 public class Cutouts {
     public static void init() {
-        ItemBlockRenderTypes.setRenderLayer(Registry.PEAT, RenderType.cutoutMipped());
-        ItemBlockRenderTypes.setRenderLayer(Registry.RHODODENDRON, RenderType.cutoutMipped());
+        ItemBlockRenderTypes.setRenderLayer(Registry.PEAT.get(), RenderType.cutoutMipped());
+        ItemBlockRenderTypes.setRenderLayer(Registry.RHODODENDRON.get(), RenderType.cutoutMipped());
     }
 }

--- a/src/main/java/com/oitsjustjose/geolosys/client/render/GeolosysClient.java
+++ b/src/main/java/com/oitsjustjose/geolosys/client/render/GeolosysClient.java
@@ -1,0 +1,30 @@
+package com.oitsjustjose.geolosys.client.render;
+
+import com.oitsjustjose.geolosys.common.config.ClientConfig;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+public class GeolosysClient {
+    public static void setup() {
+        MinecraftForge.EVENT_BUS.register(GeolosysClient.class);
+        MinecraftForge.EVENT_BUS.register(ProPickOverlay.class);
+    }
+
+    @SubscribeEvent
+    public void onHover(ItemTooltipEvent event) {
+        if (!ClientConfig.ENABLE_TAG_DEBUG.get()) {
+            return;
+        }
+
+        Minecraft mc = Minecraft.getInstance();
+
+        if (mc.options.advancedItemTooltips) {
+            event.getItemStack().getTags().forEach(x -> {
+                event.getToolTip().add(new TextComponent("\u00A78#" + x.location() + "\u00A7r"));
+            });
+        }
+    }
+}

--- a/src/main/java/com/oitsjustjose/geolosys/client/render/ProPickOverlay.java
+++ b/src/main/java/com/oitsjustjose/geolosys/client/render/ProPickOverlay.java
@@ -1,0 +1,42 @@
+package com.oitsjustjose.geolosys.client.render;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.oitsjustjose.geolosys.common.config.ClientConfig;
+import com.oitsjustjose.geolosys.common.items.ProPickItem;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.language.I18n;
+import net.minecraft.world.InteractionHand;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import org.lwjgl.opengl.GL11;
+
+public class ProPickOverlay {
+    @SubscribeEvent
+    public static void onDrawScreen(RenderGameOverlayEvent.Post event) {
+        Minecraft mc = Minecraft.getInstance();
+
+        if (event.getType() != RenderGameOverlayEvent.ElementType.ALL || mc.options.renderDebug
+                || mc.options.renderDebugCharts) {
+            return;
+        }
+        if (mc.player.getItemInHand(InteractionHand.MAIN_HAND).getItem() instanceof ProPickItem
+                || mc.player.getItemInHand(InteractionHand.OFF_HAND).getItem() instanceof ProPickItem) {
+            GlStateManager._enableBlend();
+            GlStateManager._blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+            int seaLvl = mc.player.getLevel().getSeaLevel();
+            int level = (int) (seaLvl - mc.player.getY());
+            if (level < 0) {
+                mc.font.draw(event.getMatrixStack(),
+                        I18n.get("geolosys.pro_pick.depth.above", Math.abs(level)),
+                        (float) ClientConfig.PROPICK_HUD_X.get(), (float) ClientConfig.PROPICK_HUD_Y.get(), 0xFFFFFFFF);
+            } else if (level == 0) {
+                mc.font.draw(event.getMatrixStack(), I18n.get("geolosys.pro_pick.depth.at"),
+                        (float) ClientConfig.PROPICK_HUD_X.get(), (float) ClientConfig.PROPICK_HUD_Y.get(), 0xFFFFFFFF);
+            } else {
+                mc.font.draw(event.getMatrixStack(),
+                        I18n.get("geolosys.pro_pick.depth.below", Math.abs(level)),
+                        (float) ClientConfig.PROPICK_HUD_X.get(), (float) ClientConfig.PROPICK_HUD_Y.get(), 0xFFFFFFFF);
+            }
+        }
+    }
+}

--- a/src/main/java/com/oitsjustjose/geolosys/common/blocks/PlantBlock.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/blocks/PlantBlock.java
@@ -1,9 +1,5 @@
 package com.oitsjustjose.geolosys.common.blocks;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
@@ -17,17 +13,20 @@ import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.registries.RegistryObject;
+
+import java.util.Random;
 
 public class PlantBlock extends BushBlock {
-    public List<Block> placelist;
-    private boolean isExclusive;
+    public RegistryObject<Block> placelist;
+    private final boolean isExclusive;
 
-    public PlantBlock(boolean exclusive, Block... placeable) {
+    public PlantBlock(boolean exclusive, RegistryObject<Block> placeable) {
         super(Properties.of(Material.PLANT)
                 .noCollission()
                 .sound(SoundType.SWEET_BERRY_BUSH)
                 .randomTicks());
-        this.placelist = Arrays.asList(placeable);
+        this.placelist = placeable;
         this.isExclusive = exclusive;
     }
 
@@ -42,20 +41,20 @@ public class PlantBlock extends BushBlock {
     public boolean canSurvive(BlockState state, LevelReader worldIn, BlockPos pos) {
         BlockState below = worldIn.getBlockState(pos.below());
         if (this.isExclusive) {
-            return placelist.contains(below.getBlock());
+            return placelist.get().equals(below.getBlock());
         }
-        return super.canSurvive(state, worldIn, pos) || placelist.contains(below.getBlock());
+        return super.canSurvive(state, worldIn, pos) || placelist.get().equals(below.getBlock());
     }
 
     @Override
     public void randomTick(BlockState state, ServerLevel worldIn, BlockPos pos, Random random) {
-        if (this.placelist.contains(worldIn.getBlockState(pos.below()).getBlock())
+        if (this.placelist.get().equals(worldIn.getBlockState(pos.below()).getBlock())
                 && worldIn.getRawBrightness(pos.above(), 0) >= 9
                 && net.minecraftforge.common.ForgeHooks.onCropsGrowPre(worldIn, pos, state, random.nextInt(10) == 0)) {
             for (int x = -1; x <= 1; x++) {
                 for (int z = -1; z <= 1; z++) {
                     if (worldIn.getBlockState(pos.offset(x, 0, z)).isAir()
-                            && this.placelist.contains(worldIn.getBlockState(pos.offset(x, -1, z)).getBlock())) {
+                            && this.placelist.get().equals(worldIn.getBlockState(pos.offset(x, -1, z)).getBlock())) {
                         worldIn.setBlock(pos.offset(x, 0, z), this.defaultBlockState(), 2 | 16);
                         return;
                     }

--- a/src/main/java/com/oitsjustjose/geolosys/common/blocks/Types.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/blocks/Types.java
@@ -1,6 +1,7 @@
 package com.oitsjustjose.geolosys.common.blocks;
 
 import net.minecraft.world.level.block.Block;
+import net.minecraftforge.registries.RegistryObject;
 
 import javax.annotation.Nullable;
 
@@ -33,8 +34,8 @@ public class Types {
         private final String unlocalizedName;
         private final int xp;
 
-        private Block instance;
-        private Block sample;
+        private RegistryObject<Block> instance;
+        private RegistryObject<Block> sample;
 
         Ores(String unlocalizedName, int xp) {
             this.unlocalizedName = unlocalizedName;
@@ -54,20 +55,20 @@ public class Types {
         }
 
         @Nullable
-        public Block getBlock() {
+        public RegistryObject<Block> getBlock() {
             return this.instance;
         }
 
         @Nullable
-        public Block getSample() {
+        public RegistryObject<Block> getSample() {
             return this.sample;
         }
 
-        public void setBlock(Block b) {
+        public void setBlock(RegistryObject<Block> b) {
             this.instance = b;
         }
 
-        public void setSample(Block b) {
+        public void setSample(RegistryObject<Block> b) {
             this.sample = b;
         }
     }
@@ -98,8 +99,8 @@ public class Types {
         private final String unlocalizedName;
         private final int xp;
 
-        private Block instance;
-        private Block sample;
+        private RegistryObject<Block> instance;
+        private RegistryObject<Block> sample;
         private Ores origin;
 
         DeepslateOres(String unlocalizedName, Ores origin, int xp) {
@@ -121,7 +122,7 @@ public class Types {
         }
 
         @Nullable
-        public Block getBlock() {
+        public RegistryObject<Block> getBlock() {
             return this.instance;
         }
 
@@ -131,15 +132,15 @@ public class Types {
         }
 
         @Nullable
-        public Block getSample() {
+        public RegistryObject<Block> getSample() {
             return this.sample;
         }
 
-        public void setBlock(Block b) {
+        public void setBlock(RegistryObject<Block> b) {
             this.instance = b;
         }
 
-        public void setSample(Block b) {
+        public void setSample(RegistryObject<Block> b) {
             this.sample = b;
         }
     }

--- a/src/main/java/com/oitsjustjose/geolosys/common/items/ProPickItem.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/items/ProPickItem.java
@@ -1,23 +1,12 @@
 package com.oitsjustjose.geolosys.common.items;
 
-import java.util.HashSet;
-
-import com.mojang.blaze3d.platform.GlStateManager;
 import com.oitsjustjose.geolosys.Geolosys;
-import com.oitsjustjose.geolosys.common.config.ClientConfig;
 import com.oitsjustjose.geolosys.common.config.CommonConfig;
-import com.oitsjustjose.geolosys.common.utils.Constants;
 import com.oitsjustjose.geolosys.common.utils.GeolosysGroup;
 import com.oitsjustjose.geolosys.common.utils.Prospecting;
-
-import org.lwjgl.opengl.GL11;
-
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.language.I18n;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.TranslatableComponent;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
@@ -29,13 +18,10 @@ import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.client.event.RenderGameOverlayEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+import java.util.HashSet;
 
 public class ProPickItem extends Item {
-    public static final ResourceLocation REGISTRY_NAME = new ResourceLocation(Constants.MODID, "prospectors_pick");
     public static Item.Properties props = CommonConfig.ENABLE_PRO_PICK_DMG.get()
             ? new Item.Properties().stacksTo(1).tab(GeolosysGroup.getInstance())
                     .durability(CommonConfig.PRO_PICK_DURABILITY.get())
@@ -43,7 +29,6 @@ public class ProPickItem extends Item {
 
     public ProPickItem() {
         super(props);
-        this.setRegistryName(REGISTRY_NAME);
         Geolosys.proxy.registerClientSubscribeEvent(this);
     }
 
@@ -138,35 +123,5 @@ public class ProPickItem extends Item {
 
         player.displayClientMessage(new TranslatableComponent("geolosys.pro_pick.tooltip.nonefound_surface"), true);
         return false;
-    }
-
-    @SubscribeEvent
-    @OnlyIn(Dist.CLIENT)
-    public void onDrawScreen(RenderGameOverlayEvent.Post event) {
-        Minecraft mc = Minecraft.getInstance();
-
-        if (event.getType() != RenderGameOverlayEvent.ElementType.ALL || mc.options.renderDebug
-                || mc.options.renderDebugCharts) {
-            return;
-        }
-        if (mc.player.getItemInHand(InteractionHand.MAIN_HAND).getItem() instanceof ProPickItem
-                || mc.player.getItemInHand(InteractionHand.OFF_HAND).getItem() instanceof ProPickItem) {
-            GlStateManager._enableBlend();
-            GlStateManager._blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-            int seaLvl = mc.player.getLevel().getSeaLevel();
-            int level = (int) (seaLvl - mc.player.getY());
-            if (level < 0) {
-                mc.font.draw(event.getMatrixStack(),
-                        I18n.get("geolosys.pro_pick.depth.above", Math.abs(level)),
-                        (float) ClientConfig.PROPICK_HUD_X.get(), (float) ClientConfig.PROPICK_HUD_Y.get(), 0xFFFFFFFF);
-            } else if (level == 0) {
-                mc.font.draw(event.getMatrixStack(), I18n.get("geolosys.pro_pick.depth.at"),
-                        (float) ClientConfig.PROPICK_HUD_X.get(), (float) ClientConfig.PROPICK_HUD_Y.get(), 0xFFFFFFFF);
-            } else {
-                mc.font.draw(event.getMatrixStack(),
-                        I18n.get("geolosys.pro_pick.depth.below", Math.abs(level)),
-                        (float) ClientConfig.PROPICK_HUD_X.get(), (float) ClientConfig.PROPICK_HUD_Y.get(), 0xFFFFFFFF);
-            }
-        }
     }
 }

--- a/src/main/java/com/oitsjustjose/geolosys/common/items/Types.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/items/Types.java
@@ -1,13 +1,14 @@
 package com.oitsjustjose.geolosys.common.items;
 
 import net.minecraft.world.item.Item;
+import net.minecraftforge.registries.RegistryObject;
 
 public class Types {
     public enum Coals {
         PEAT(6, "peat", false), LIGNITE(12, "lignite", false), BITUMINOUS(16, "bituminous", false),
         ANTHRACITE(20, "anthracite", false), LIGNITE_COKE(24, "lignite", true), BITUMINOUS_COKE(32, "bituminous", true);
 
-        private Item instance;
+        private RegistryObject<Item> instance;
 
         private final int burnTime;
         private final String serializedName;
@@ -41,11 +42,11 @@ public class Types {
             return this.isCoalCoke;
         }
 
-        public void setItem(Item i) {
+        public void setItem(RegistryObject<Item> i) {
             this.instance = i;
         }
 
-        public Item getItem() {
+        public RegistryObject<Item> getItem() {
             return this.instance;
         }
     }
@@ -54,7 +55,7 @@ public class Types {
         TIN("tin"), SILVER("silver"), LEAD("lead"), ALUMINUM("aluminum"), NICKEL("nickel"),
         PLATINUM("platinum"), ZINC("zinc");
 
-        private Item instance;
+        private RegistryObject<Item> instance;
 
         private final String serializedName;
         private final String unlocalizedName;
@@ -76,11 +77,11 @@ public class Types {
             return this.serializedName;
         }
 
-        public void setItem(Item i) {
+        public void setItem(RegistryObject<Item> i) {
             this.instance = i;
         }
 
-        public Item getItem() {
+        public RegistryObject<Item> getItem() {
             return this.instance;
         }
     }
@@ -89,7 +90,7 @@ public class Types {
         COPPER("copper"), TIN("tin"), SILVER("silver"), LEAD("lead"), ALUMINUM("aluminum"), NICKEL("nickel"),
         PLATINUM("platinum"), ZINC("zinc");
 
-        private Item instance;
+        private RegistryObject<Item> instance;
 
         private final String serializedName;
         private final String unlocalizedName;
@@ -111,11 +112,11 @@ public class Types {
             return this.serializedName;
         }
 
-        public void setItem(Item i) {
+        public void setItem(RegistryObject<Item> i) {
             this.instance = i;
         }
 
-        public Item getItem() {
+        public RegistryObject<Item> getItem() {
             return this.instance;
         }
     }
@@ -125,7 +126,7 @@ public class Types {
         NICKEL("nickel"), PLATINUM("platinum"), URANIUM("uranium"), ZINC("zinc"), YELLORIUM("yellorium"),
         OSMIUM("osmium"), ANCIENT_DEBRIS("ancient_debris"), NETHER_GOLD("nether_gold");
 
-        private Item instance;
+        private RegistryObject<Item> instance;
 
         private final String serializedName;
         private final String unlocalizedName;
@@ -147,11 +148,11 @@ public class Types {
             return this.serializedName;
         }
 
-        public void setItem(Item i) {
+        public void setItem(RegistryObject<Item> i) {
             this.instance = i;
         }
 
-        public Item getItem() {
+        public RegistryObject<Item> getItem() {
             return this.instance;
         }
     }

--- a/src/main/java/com/oitsjustjose/geolosys/common/network/PacketStackSurface.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/network/PacketStackSurface.java
@@ -1,14 +1,8 @@
 package com.oitsjustjose.geolosys.common.network;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.chat.TranslatableComponent;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.network.NetworkEvent;
 
 import java.util.HashSet;
@@ -37,23 +31,5 @@ public class PacketStackSurface {
 
     public void handleServer(Supplier<NetworkEvent.Context> context) {
         context.get().setPacketHandled(true);
-    }
-
-    @OnlyIn(Dist.CLIENT)
-    public static void handleClient(PacketStackSurface msg, Supplier<NetworkEvent.Context> context) {
-        if (context.get().getDirection().getReceptionSide() == LogicalSide.CLIENT) {
-            context.get().enqueueWork(() -> {
-                Minecraft mc = Minecraft.getInstance();
-                sendProspectingMessage(mc.player, PacketHelpers.messagify(msg.blocks));
-            });
-        }
-        context.get().setPacketHandled(true);
-    }
-
-    @OnlyIn(Dist.CLIENT)
-    private static void sendProspectingMessage(Player player, Object... messageDecorators) {
-        TranslatableComponent msg = new TranslatableComponent("geolosys.pro_pick.tooltip.found_surface",
-                messageDecorators);
-        player.displayClientMessage(msg, true);
     }
 }

--- a/src/main/java/com/oitsjustjose/geolosys/common/network/PacketStackUnderground.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/network/PacketStackUnderground.java
@@ -1,14 +1,8 @@
 package com.oitsjustjose.geolosys.common.network;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-import net.minecraftforge.fml.LogicalSide;
 import net.minecraftforge.network.NetworkEvent;
 
 import java.util.HashSet;
@@ -40,23 +34,5 @@ public class PacketStackUnderground {
 
     public void handleServer(Supplier<NetworkEvent.Context> context) {
         context.get().setPacketHandled(true);
-    }
-
-    @OnlyIn(Dist.CLIENT)
-    public static void handleClient(PacketStackUnderground msg, Supplier<NetworkEvent.Context> context) {
-        if (context.get().getDirection().getReceptionSide() == LogicalSide.CLIENT) {
-            context.get().enqueueWork(() -> {
-                Minecraft mc = Minecraft.getInstance();
-                sendProspectingMessage(mc.player, PacketHelpers.messagify(msg.blocks), msg.direction);
-            });
-        }
-        context.get().setPacketHandled(true);
-    }
-
-    @OnlyIn(Dist.CLIENT)
-    private static void sendProspectingMessage(LocalPlayer player, Object... messageDecorators) {
-        TranslatableComponent msg = new TranslatableComponent("geolosys.pro_pick.tooltip.found",
-                messageDecorators);
-        player.displayClientMessage(msg, true);
     }
 }

--- a/src/main/java/com/oitsjustjose/geolosys/common/utils/GeolosysGroup.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/utils/GeolosysGroup.java
@@ -4,8 +4,6 @@ import com.oitsjustjose.geolosys.common.blocks.Types.Ores;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 public class GeolosysGroup extends CreativeModeTab {
     private static GeolosysGroup instance;
@@ -31,7 +29,6 @@ public class GeolosysGroup extends CreativeModeTab {
     }
 
     @Override
-    @OnlyIn(Dist.CLIENT)
     public ItemStack getIconItem() {
         // Init the anim only when the first ore is init'd
         if (Ores.COAL.getBlock() != null && counter == -1) {
@@ -39,7 +36,7 @@ public class GeolosysGroup extends CreativeModeTab {
         }
 
         if (System.currentTimeMillis() - lastTick > 1000L) {
-            display = new ItemStack(Ores.values()[counter].getBlock());
+            display = new ItemStack(Ores.values()[counter].getBlock().get());
             counter = counter == (Ores.values().length - 1) ? 0 : counter + 1;
             lastTick = System.currentTimeMillis();
         }


### PR DESCRIPTION
Fix general good practice by:
- Removing `@OnlyIn` annotation where necessary and refactoring code for client/server seperation.
- Changing registry system to use DeferredRegister to avoid log spam and occasional crashing.

This should, among other things, future-proof the code a bit, as well as stopping the constant log spam during loading caused by the old system and should also, at least as far as I can tell, fix the occasional crashes I was experiencing with the old system.