### PR TITLE
Properly replace ore blocks in vein structures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,10 @@ dependencies {
 
 repositories {
     maven { url 'https://maven.blamejared.com' }
-    repositories {
-        maven {
-            url "https://www.cursemaven.com"
+    maven {
+        url "https://www.cursemaven.com"
+        content {
+            includeGroup "curse.maven"
         }
     }
 }
@@ -70,19 +71,20 @@ repositories {
 dependencies {
     compileOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}:api")
     runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
+    implementation fg.deobf("curse.maven:worldstripper-250603:3670854")
 }
 
 // Example for how to get properties into the manifest for reading by the runtime..
 jar {
     manifest {
         attributes([
-            "Specification-Title": "geolosys",
-            "Specification-Vendor": "oitsjustjose.com",
-            "Specification-Version": "1", // We are version 1 of ourselves
-            "Implementation-Title": project.name,
-            "Implementation-Version": "${mod_version}",
-            "Implementation-Vendor" :"oitsjustjose.com",
-            "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
+                "Specification-Title"     : "geolosys",
+                "Specification-Vendor"    : "oitsjustjose.com",
+                "Specification-Version"   : "1", // We are version 1 of ourselves
+                "Implementation-Title"    : project.name,
+                "Implementation-Version"  : "${mod_version}",
+                "Implementation-Vendor"   : "oitsjustjose.com",
+                "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
         ])
     }
 }
@@ -125,35 +127,35 @@ tasks.register('modrinth', TaskModrinthUpload.class).configure {
 }
 
 curseforge {
-  apiKey = project.hasProperty("CURSEFORGE_API_KEY") ? project.CURSEFORGE_API_KEY : ""
-  project {
-    id = '271856'
-    changelogType = 'markdown'
-    changelog = file("./changelog.md")
-    releaseType = 'release'
-    addGameVersion project.game_version
-    
-    relations {
-      requiredDependency 'patchouli'
-      optionalDependency 'applied-energistics-2'
-      optionalDependency 'extreme-reactors'
-      optionalDependency 'biggerreactors'
-      optionalDependency 'mekanism'
-    }
+    apiKey = project.hasProperty("CURSEFORGE_API_KEY") ? project.CURSEFORGE_API_KEY : ""
+    project {
+        id = '271856'
+        changelogType = 'markdown'
+        changelog = file("./changelog.md")
+        releaseType = 'release'
+        addGameVersion project.game_version
 
-    mainArtifact(jar) {
-        displayName = "Geolosys ${game_version} ${mod_version}"
-    }
+        relations {
+            requiredDependency 'patchouli'
+            optionalDependency 'applied-energistics-2'
+            optionalDependency 'extreme-reactors'
+            optionalDependency 'biggerreactors'
+            optionalDependency 'mekanism'
+        }
+
+        mainArtifact(jar) {
+            displayName = "Geolosys ${game_version} ${mod_version}"
+        }
 
 
-    addArtifact(deobfJar) {
-        displayName = "Geolosys ${game_version} ${mod_version} Deobf"
-    }
+        addArtifact(deobfJar) {
+            displayName = "Geolosys ${game_version} ${mod_version} Deobf"
+        }
 
-    addArtifact(sourcesJar){
-        displayName = "Geolosys ${game_version} ${mod_version} Sources"
+        addArtifact(sourcesJar) {
+            displayName = "Geolosys ${game_version} ${mod_version} Sources"
+        }
     }
-  }
 }
 
 publishing {

--- a/src/main/java/com/oitsjustjose/geolosys/common/config/CommonConfig.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/config/CommonConfig.java
@@ -18,6 +18,7 @@ public class CommonConfig {
     public static ForgeConfigSpec.BooleanValue DEBUG_WORLD_GEN;
     public static ForgeConfigSpec.BooleanValue ADVANCED_DEBUG_WORLD_GEN;
     public static ForgeConfigSpec.BooleanValue REMOVE_VANILLA_ORES;
+    public static ForgeConfigSpec.BooleanValue REMOVE_VEIN_ORES;
     public static ForgeConfigSpec.DoubleValue CHUNK_SKIP_CHANCE;
     public static ForgeConfigSpec.IntValue MAX_SAMPLES_PER_CHUNK;
     public static ForgeConfigSpec.IntValue NUMBER_PLUTONS_PER_CHUNK;
@@ -61,6 +62,8 @@ public class CommonConfig {
                 .define("advancedDebugWorldGen", false);
         REMOVE_VANILLA_ORES = COMMON_BUILDER.comment("Disable generation of Vanilla ores")
                 .define("disableVanillaOreGen", true);
+        REMOVE_VEIN_ORES = COMMON_BUILDER.comment("If \"disableVanillaOreGen\" is set to true, setting this to false will allow \nyou to replace vanilla ores associated with ore veins with geolosys equivalents.")
+                .define("removeVeinOres", false);
         DEFAULT_REPLACEMENT_MATS = COMMON_BUILDER.comment(
                 "The fallback materials which a Deposit can replace if they're not specified by the deposit itself\n"
                         + "Format: Comma-delimited set of <modid:block> (see default for example)")

--- a/src/main/java/com/oitsjustjose/geolosys/common/world/feature/RemoveVeinsFeature.java
+++ b/src/main/java/com/oitsjustjose/geolosys/common/world/feature/RemoveVeinsFeature.java
@@ -1,6 +1,7 @@
 package com.oitsjustjose.geolosys.common.world.feature;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -23,14 +24,45 @@ import net.minecraft.world.level.levelgen.FlatLevelSource;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
 import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
+import net.minecraftforge.registries.ObjectHolder;
 
 public class RemoveVeinsFeature extends Feature<NoneFeatureConfiguration> {
 
-    private final ArrayList<Block> UNACCEPTABLE = Lists.newArrayList(Blocks.RAW_IRON_BLOCK, Blocks.RAW_COPPER_BLOCK,
-            Blocks.DEEPSLATE_IRON_ORE, Blocks.COPPER_ORE);
+    private final ArrayList<Block> UNACCEPTABLE = Lists.newArrayList(
+            Blocks.RAW_IRON_BLOCK,
+            Blocks.RAW_COPPER_BLOCK,
+            Blocks.DEEPSLATE_IRON_ORE,
+            Blocks.COPPER_ORE
+    );
 
+    // TODO get better way to get instances of the blocks
+    @ObjectHolder("geolosys:malachite_ore")
+    public static final Block geolosysMalachiteOreBlock = null;
+
+    @ObjectHolder("geolosys:deepslate_hematite_ore")
+    public static final Block geolosysDeepslateHematiteOreBlock = null;
+
+    private final HashMap<Block, Block> oreReplacementMap;
     public RemoveVeinsFeature(Codec<NoneFeatureConfiguration> p_i231976_1_) {
         super(p_i231976_1_);
+        oreReplacementMap = initOreReplacementMap();
+    }
+
+    private HashMap<Block, Block> initOreReplacementMap() {
+        HashMap<Block, Block> map = new HashMap<>(){{
+            put(Blocks.COPPER_ORE, geolosysMalachiteOreBlock);
+            put(Blocks.RAW_COPPER_BLOCK, geolosysMalachiteOreBlock);
+            put(Blocks.DEEPSLATE_IRON_ORE, geolosysDeepslateHematiteOreBlock);
+            put(Blocks.RAW_IRON_BLOCK, geolosysDeepslateHematiteOreBlock);
+        }};
+
+        if (CommonConfig.REMOVE_VEIN_ORES.get()) {
+            map.put(Blocks.COPPER_ORE, Blocks.STONE);
+            map.put(Blocks.RAW_COPPER_BLOCK, Blocks.STONE);
+            map.put(Blocks.DEEPSLATE_IRON_ORE, Blocks.DEEPSLATE);
+            map.put(Blocks.RAW_IRON_BLOCK, Blocks.DEEPSLATE);
+        }
+        return map;
     }
 
     public final RemoveVeinsFeature withRegistryName(String modID, String name) {
@@ -64,8 +96,8 @@ public class RemoveVeinsFeature extends Feature<NoneFeatureConfiguration> {
                     BlockPos p = new BlockPos(x, y, z);
                     BlockState state = level.getBlockState(p);
                     if (UNACCEPTABLE.contains(state.getBlock())) {
-                        FeatureUtils.enqueueBlockPlacement(level, cp, p, Blocks.TUFF.defaultBlockState(), deposits,
-                                chunks);
+                        BlockState properReplacement = oreReplacementMap.get(state.getBlock()).defaultBlockState();
+                        FeatureUtils.enqueueBlockPlacement(level, cp, p, properReplacement, deposits, chunks);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #310 

This pull request fixes the current issue with ore replacement in vanilla veins. Where with the current approach all vanilla ore blocks that are associated with veins - namely: copper and iron and their raw block variants -  are bluntly replaced with tuff. As an alternative solution in this PR; The ores are replaced by default by stone or deepslate according to their vein type. 

Furthermore, a new config option was introduced `removeVeinOres` that (when set to `false`) enables the replacement of vanilla ores in veins with geolosys equivalents so that the veins can optionally keep there intended function.

![CopperOreVein](https://user-images.githubusercontent.com/2453422/172030526-55ff37f3-b193-4b37-a464-00a841889dd3.jpg)
_- Notice: Malachite ore replacing vanilla copper ores in copper veins_
 
![DeepslateIronOreVein](https://user-images.githubusercontent.com/2453422/172030535-2d9ad066-25c9-4e70-8a3c-f0c1df23ab25.jpg)
_- Notice: Deepslate hematite ore replacing iron deepslate ores in iron veins_
