### PR TITLE
Improved chunk generation speed, fix #305, fix floating point error bug

### DIFF
--- a/src/main/java/com/oitsjustjose/geolosys/api/world/DepositUtils.java
+++ b/src/main/java/com/oitsjustjose/geolosys/api/world/DepositUtils.java
@@ -12,7 +12,6 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map.Entry;
-import java.util.Random;
 
 public class DepositUtils {
     private static HashSet<BlockState> defaultMatchersCached = null;
@@ -28,13 +27,6 @@ public class DepositUtils {
      */
     @Nullable
     public static BlockState pick(HashMap<BlockState, Float> map, float totl, RandomSource random) {
-        if (totl == 1.0F) {
-            totl = 0;
-            for (Entry<BlockState, Float> e : map.entrySet()) {
-                totl += e.getValue();
-            }
-        }
-
         float rng = random.nextFloat();
         for (Entry<BlockState, Float> e : map.entrySet()) {
             float wt = e.getValue();
@@ -71,5 +63,13 @@ public class DepositUtils {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Returns true if a and b are within epsilon of each other, where epsilon is the minimum
+     * representable value by a 32-bit floating point number.
+     */
+    public static boolean nearlyEquals(float a, float b) {
+        return Math.abs(a - b) <= Float.MIN_VALUE;
     }
 }

--- a/src/main/java/com/oitsjustjose/geolosys/api/world/deposit/DenseDeposit.java
+++ b/src/main/java/com/oitsjustjose/geolosys/api/world/deposit/DenseDeposit.java
@@ -71,8 +71,8 @@ public class DenseDeposit implements IDeposit {
                 float v = this.cumulOreWtMap.get(i.getKey());
                 this.cumulOreWtMap.put(i.getKey(), v + j.getValue());
             }
-
-            if (this.cumulOreWtMap.get(i.getKey()) != 1.0F) {
+            
+            if (!DepositUtils.nearlyEquals(this.cumulOreWtMap.get(i.getKey()), 1.0F)) {
                 throw new RuntimeException("Sum of weights for pluton blocks should equal 1.0");
             }
         }
@@ -81,7 +81,7 @@ public class DenseDeposit implements IDeposit {
             this.sumWtSamples += e.getValue();
         }
 
-        if (sumWtSamples != 1.0F) {
+        if (!DepositUtils.nearlyEquals(sumWtSamples, 1.0F)) {
             throw new RuntimeException("Sum of weights for pluton samples should equal 1.0");
         }
     }
@@ -97,13 +97,9 @@ public class DenseDeposit implements IDeposit {
      */
     @Nullable
     public BlockState getOre(BlockState currentState, RandomSource rand) {
-        String res = Utils.getRegistryName(currentState);
-        if (this.oreToWtMap.containsKey(res)) {
-            // Return a choice from a specialized set here
-            HashMap<BlockState, Float> mp = this.oreToWtMap.get(res);
-            return DepositUtils.pick(mp, this.cumulOreWtMap.get(res), rand);
-        }
-        return DepositUtils.pick(this.oreToWtMap.get("default"), this.cumulOreWtMap.get("default"), rand);
+        String res = this.oreToWtMap.containsKey(Utils.getRegistryName(currentState)) ? Utils.getRegistryName(currentState) : "default";
+        // Return a choice from a specialized set here
+        return DepositUtils.pick(this.oreToWtMap.get(res), this.cumulOreWtMap.get(res), rand);
     }
 
     /**

--- a/src/main/java/com/oitsjustjose/geolosys/api/world/deposit/DikeDeposit.java
+++ b/src/main/java/com/oitsjustjose/geolosys/api/world/deposit/DikeDeposit.java
@@ -72,7 +72,7 @@ public class DikeDeposit implements IDeposit {
                 this.cumulOreWtMap.put(i.getKey(), v + j.getValue());
             }
 
-            if (this.cumulOreWtMap.get(i.getKey()) != 1.0F) {
+            if (!DepositUtils.nearlyEquals(this.cumulOreWtMap.get(i.getKey()), 1.0F)) {
                 throw new RuntimeException("Sum of weights for pluton blocks should equal 1.0");
             }
         }
@@ -81,7 +81,7 @@ public class DikeDeposit implements IDeposit {
             this.sumWtSamples += e.getValue();
         }
 
-        if (sumWtSamples != 1.0F) {
+        if (!DepositUtils.nearlyEquals(sumWtSamples, 1.0F)) {
             throw new RuntimeException("Sum of weights for pluton samples should equal 1.0");
         }
     }

--- a/src/main/java/com/oitsjustjose/geolosys/api/world/deposit/LayerDeposit.java
+++ b/src/main/java/com/oitsjustjose/geolosys/api/world/deposit/LayerDeposit.java
@@ -74,7 +74,7 @@ public class LayerDeposit implements IDeposit {
                 this.cumulOreWtMap.put(i.getKey(), v + j.getValue());
             }
 
-            if (this.cumulOreWtMap.get(i.getKey()) != 1.0F) {
+            if (!DepositUtils.nearlyEquals(this.cumulOreWtMap.get(i.getKey()), 1.0F)) {
                 throw new RuntimeException("Sum of weights for pluton blocks should equal 1.0");
             }
         }
@@ -83,7 +83,7 @@ public class LayerDeposit implements IDeposit {
             this.sumWtSamples += e.getValue();
         }
 
-        if (sumWtSamples != 1.0F) {
+        if (!DepositUtils.nearlyEquals(sumWtSamples, 1.0F)) {
             throw new RuntimeException("Sum of weights for pluton samples should equal 1.0");
         }
     }

--- a/src/main/java/com/oitsjustjose/geolosys/api/world/deposit/SparseDeposit.java
+++ b/src/main/java/com/oitsjustjose/geolosys/api/world/deposit/SparseDeposit.java
@@ -75,7 +75,7 @@ public class SparseDeposit implements IDeposit {
                 this.cumulOreWtMap.put(i.getKey(), v + j.getValue());
             }
 
-            if (this.cumulOreWtMap.get(i.getKey()) != 1.0F) {
+            if (!DepositUtils.nearlyEquals(this.cumulOreWtMap.get(i.getKey()), 1.0F)) {
                 throw new RuntimeException("Sum of weights for pluton blocks should equal 1.0");
             }
         }
@@ -84,7 +84,7 @@ public class SparseDeposit implements IDeposit {
             this.sumWtSamples += e.getValue();
         }
 
-        if (sumWtSamples != 1.0F) {
+        if (!DepositUtils.nearlyEquals(sumWtSamples, 1.0F)) {
             throw new RuntimeException("Sum of weights for pluton samples should equal 1.0");
         }
     }
@@ -249,7 +249,7 @@ public class SparseDeposit implements IDeposit {
         }
 
         ChunkPos thisChunk = new ChunkPos(pos);
-        int maxSampleCnt = (Math.min(CommonConfig.MAX_SAMPLES_PER_CHUNK.get(), (this.size / CommonConfig.MAX_SAMPLES_PER_CHUNK.get()) + (this.size % CommonConfig.MAX_SAMPLES_PER_CHUNK.get()))) * (spread / 16);
+        int maxSampleCnt = (int)((float)Math.min(CommonConfig.MAX_SAMPLES_PER_CHUNK.get(), (this.size / CommonConfig.MAX_SAMPLES_PER_CHUNK.get()) + (this.size % CommonConfig.MAX_SAMPLES_PER_CHUNK.get())) * ((float)spread / 16.0F));
 
         for (int i = 0; i < maxSampleCnt; i++) {
             BlockState tmp = this.getSample(level.getRandom());

--- a/src/main/java/com/oitsjustjose/geolosys/api/world/deposit/TopLayerDeposit.java
+++ b/src/main/java/com/oitsjustjose/geolosys/api/world/deposit/TopLayerDeposit.java
@@ -70,7 +70,7 @@ public class TopLayerDeposit implements IDeposit {
                 this.cumulOreWtMap.put(i.getKey(), v + j.getValue());
             }
 
-            if (this.cumulOreWtMap.get(i.getKey()) != 1.0F) {
+            if (!DepositUtils.nearlyEquals(this.cumulOreWtMap.get(i.getKey()), 1.0F)) {
                 throw new RuntimeException("Sum of weights for pluton blocks should equal 1.0");
             }
         }
@@ -79,7 +79,7 @@ public class TopLayerDeposit implements IDeposit {
             this.sumWtSamples += e.getValue();
         }
 
-        if (sumWtSamples != 1.0F) {
+        if (!DepositUtils.nearlyEquals(sumWtSamples, 1.0F)) {
             throw new RuntimeException("Sum of weights for pluton samples should equal 1.0");
         }
     }

--- a/src/main/java/com/oitsjustjose/geolosys/capability/world/ChunkGennedCapability.java
+++ b/src/main/java/com/oitsjustjose/geolosys/capability/world/ChunkGennedCapability.java
@@ -1,6 +1,6 @@
 package com.oitsjustjose.geolosys.capability.world;
 
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentHashMap;
 
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -10,13 +10,13 @@ import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.common.capabilities.CapabilityToken;
 
 public class ChunkGennedCapability implements IChunkGennedCapability {
-    private final ConcurrentLinkedQueue<ChunkPos> generatedChunks;
+    private final ConcurrentHashMap.KeySetView<ChunkPos, Boolean> generatedChunks;
 
     public static final Capability<IChunkGennedCapability> CAPABILITY = CapabilityManager.get(new CapabilityToken<>() {
     });
 
     public ChunkGennedCapability() {
-        this.generatedChunks = new ConcurrentLinkedQueue<>();
+        this.generatedChunks = ConcurrentHashMap.newKeySet();
     }
 
     @Override


### PR DESCRIPTION
Chunk generation times should now be a significantly faster, and are now constant time (they were O(n) before). Fix #305, samples should now always generate, and fixed a bug where generation weights didn't add up to one because of floating point error.